### PR TITLE
install requirements when virtualenv is created

### DIFF
--- a/deployer/tasks/virtualenv.py
+++ b/deployer/tasks/virtualenv.py
@@ -12,4 +12,4 @@ def setup_virtualenv(python_version='', app_name='', app_dir='', repo_url=''):
     if run("pyenv virtualenv {0} {1}-{0}".format(python_version, app_name)).failed:
         print(yellow("Virtualenv already exists"))
 
-        install_requirements(app_name, python_version)
+    install_requirements(app_name, python_version)


### PR DESCRIPTION
when running `setup_virtualenv` requirements where installed only if the virtualenv existed before.